### PR TITLE
fix: correct StartMachine endpoint to POST /vm/spawn

### DIFF
--- a/internal/tools/machines.go
+++ b/internal/tools/machines.go
@@ -132,17 +132,13 @@ func (t *StartMachine) Execute(ctx context.Context, args map[string]interface{})
 		return nil, fmt.Errorf("machine_id is required")
 	}
 
-	// Build request payload
+	// Build request payload — body must be {"machine_id": N}
 	payload := htb.MachineActionRequest{
 		MachineID: int(machineID),
 	}
 
-	// Determine the correct endpoint based on machine type
-	// For now, we'll use the standard machine endpoint
-	endpoint := fmt.Sprintf("/machine/play/%d", int(machineID))
-
-	// Make API request
-	data, err := t.client.PostWithParsing(ctx, endpoint, payload, "")
+	// Spawn the machine via the correct v4 API endpoint
+	data, err := t.client.PostWithParsing(ctx, "/vm/spawn", payload, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to start machine: %w", err)
 	}


### PR DESCRIPTION
## What was broken

`StartMachine.Execute()` was posting to `/machine/play/{id}`, which does not exist in the HTB API v4. Every call to `start_machine` returned a 404 error from the API:

```
The route api/v4/machine/play/847 could not be found.
```

## The fix

Replace the non-existent endpoint with the correct one: `POST /vm/spawn` with a JSON body of `{"machine_id": N}`.

```go
// Before
endpoint := fmt.Sprintf("/machine/play/%d", int(machineID))
data, err := t.client.PostWithParsing(ctx, endpoint, payload, "")

// After
data, err := t.client.PostWithParsing(ctx, "/vm/spawn", payload, "")
```

The `MachineActionRequest` payload struct already carries `machine_id`, so no other changes are needed — the existing payload is correct for the new endpoint.

## Verification

Confirmed via HAR capture from Firefox DevTools while spawning a machine through the HTB web UI. The browser issues:

```
POST https://labs.hackthebox.com/api/v4/vm/spawn
Content-Type: application/json

{"machine_id": 847}
```

Response:
```json
{"message": "Machine deployed to lab.", "success": true}
```